### PR TITLE
renovate.json: Omit explicit additionalReviewers

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,9 +6,6 @@
   "addLabels": [
     "dependencies"
   ],
-  "additionalReviewers": [
-    "stephengtuggy"
-  ],
   "assigneesFromCodeOwners": true,
   "reviewersFromCodeOwners": true,
   "minimumReleaseAge": "1d",


### PR DESCRIPTION
Assigning the Code Owner(s) should be sufficient.