### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -7,6 +7,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/stephengtuggy/hello-nest-js/security/code-scanning/1](https://github.com/stephengtuggy/hello-nest-js/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify the minimal permissions required for the workflow to function. Since the workflow primarily involves checking out the repository, setting up Node.js, installing dependencies, building, and running tests, it only requires `contents: read` permissions. This change ensures that the workflow does not have unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
